### PR TITLE
update readme to work well on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Test:
 
 ### Usage
 
- * Compile: `mbed test --compile -m TARGET -t TOOLCHAIN --app-config mbed_app.json -n '*stress*'`
+ * Compile: `mbed test --compile -m TARGET -t TOOLCHAIN --app-config mbed_app.json -n "*stress*"`
  * Run: `mbedgt -vV`
  * Note: the tests can run for 60 minutes.
 


### PR DESCRIPTION
On windows the mbed test command is not working using single quotes, use double