### PR TITLE
Update to Mbed OS 5.10.0

### DIFF
--- a/TESTS/stress/network-http-multiple/main.cpp
+++ b/TESTS/stress/network-http-multiple/main.cpp
@@ -27,8 +27,6 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#include "easy-connect.h"
-
 #include <string>
 
 using namespace utest::v1;
@@ -206,8 +204,13 @@ void download(void)
 
 static control_t setup_network(const size_t call_count)
 {
-    interface = easy_connect(true);
+    interface = NetworkInterface::get_default_instance();
     TEST_ASSERT_NOT_NULL_MESSAGE(interface, "failed to initialize network");
+
+    nsapi_error_t err = interface->connect();
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    printf("IP address is '%s'\n", interface->get_ip_address());
+    printf("MAC address is '%s'\n", interface->get_mac_address());
 
     return CaseNext;
 }

--- a/TESTS/stress/network-http-range/main.cpp
+++ b/TESTS/stress/network-http-range/main.cpp
@@ -27,7 +27,6 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#include "easy-connect.h"
 #include "mbed_stress_test_network.h"
 
 using namespace utest::v1;
@@ -72,8 +71,13 @@ void download(size_t size)
 
 static control_t setup_network(const size_t call_count)
 {
-    interface = easy_connect(true);
+    interface = NetworkInterface::get_default_instance();
     TEST_ASSERT_NOT_NULL_MESSAGE(interface, "failed to initialize network");
+
+    nsapi_error_t err = interface->connect();
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    printf("IP address is '%s'\n", interface->get_ip_address());
+    printf("MAC address is '%s'\n", interface->get_mac_address());
 
     return CaseNext;
 }

--- a/TESTS/stress/network-http/main.cpp
+++ b/TESTS/stress/network-http/main.cpp
@@ -27,8 +27,6 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#include "easy-connect.h"
-
 #include <string>
 
 using namespace utest::v1;
@@ -90,7 +88,7 @@ void download(size_t size)
 
     /* send request to server */
     result = tcpsocket->send(request, request_size);
-    TEST_ASSERT_EQUAL_INT_MESSAGE(request_size, result, "failed to send");        
+    TEST_ASSERT_EQUAL_INT_MESSAGE(request_size, result, "failed to send");
 
 
     /* read response */
@@ -163,8 +161,13 @@ void download(size_t size)
 
 static control_t setup_network(const size_t call_count)
 {
-    interface = easy_connect(true);
+    interface = NetworkInterface::get_default_instance();
     TEST_ASSERT_NOT_NULL_MESSAGE(interface, "failed to initialize network");
+
+    nsapi_error_t err = interface->connect();
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    printf("IP address is '%s'\n", interface->get_ip_address());
+    printf("MAC address is '%s'\n", interface->get_mac_address());
 
     return CaseNext;
 }

--- a/TESTS/stress/network-https-multiple/main.cpp
+++ b/TESTS/stress/network-https-multiple/main.cpp
@@ -27,7 +27,6 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#include "easy-connect.h"
 #include "tls_socket.h"
 
 using namespace utest::v1;
@@ -35,6 +34,8 @@ using namespace utest::v1;
 #ifndef MBED_CONF_APP_DEFAULT_DOWNLOAD_SIZE
 #define MBED_CONF_APP_DEFAULT_DOWNLOAD_SIZE 1024
 #endif
+
+#define THREAD_STACK_SIZE (5 * 1024)
 
 #include MBED_CONF_APP_PROTAGONIST_DOWNLOAD
 #include "certificate_aws_s3.h"
@@ -228,15 +229,20 @@ void download(void)
 
 static control_t setup_network(const size_t call_count)
 {
-    interface = easy_connect(true);
+    interface = NetworkInterface::get_default_instance();
     TEST_ASSERT_NOT_NULL_MESSAGE(interface, "failed to initialize network");
+
+    nsapi_error_t err = interface->connect();
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    printf("IP address is '%s'\n", interface->get_ip_address());
+    printf("MAC address is '%s'\n", interface->get_mac_address());
 
     return CaseNext;
 }
 
 static control_t download_1(const size_t call_count)
 {
-    Thread t1;
+    Thread t1(osPriorityNormal, THREAD_STACK_SIZE);
 
     shared_thread_counter = 0;
     t1.start(download);
@@ -248,8 +254,8 @@ static control_t download_1(const size_t call_count)
 
 static control_t download_2(const size_t call_count)
 {
-    Thread t1;
-    Thread t2;
+    Thread t1(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t2(osPriorityNormal, THREAD_STACK_SIZE);
 
     shared_thread_counter = 0;
     t1.start(download);
@@ -263,9 +269,9 @@ static control_t download_2(const size_t call_count)
 
 static control_t download_3(const size_t call_count)
 {
-    Thread t1;
-    Thread t2;
-    Thread t3;
+    Thread t1(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t2(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t3(osPriorityNormal, THREAD_STACK_SIZE);
 
     shared_thread_counter = 0;
     t1.start(download);
@@ -281,10 +287,10 @@ static control_t download_3(const size_t call_count)
 
 static control_t download_4(const size_t call_count)
 {
-    Thread t1;
-    Thread t2;
-    Thread t3;
-    Thread t4;
+    Thread t1(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t2(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t3(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t4(osPriorityNormal, THREAD_STACK_SIZE);
 
     shared_thread_counter = 0;
     t1.start(download);
@@ -302,11 +308,11 @@ static control_t download_4(const size_t call_count)
 
 static control_t download_5(const size_t call_count)
 {
-    Thread t1;
-    Thread t2;
-    Thread t3;
-    Thread t4;
-    Thread t5;
+    Thread t1(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t2(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t3(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t4(osPriorityNormal, THREAD_STACK_SIZE);
+    Thread t5(osPriorityNormal, THREAD_STACK_SIZE);
 
     shared_thread_counter = 0;
     t1.start(download);

--- a/TESTS/stress/network-https-range/main.cpp
+++ b/TESTS/stress/network-https-range/main.cpp
@@ -27,7 +27,6 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#include "easy-connect.h"
 #include "mbed_stress_test_network.h"
 
 using namespace utest::v1;
@@ -72,8 +71,13 @@ void download(size_t size)
 
 static control_t setup_network(const size_t call_count)
 {
-    interface = easy_connect(true);
+    interface = NetworkInterface::get_default_instance();
     TEST_ASSERT_NOT_NULL_MESSAGE(interface, "failed to initialize network");
+
+    nsapi_error_t err = interface->connect();
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    printf("IP address is '%s'\n", interface->get_ip_address());
+    printf("MAC address is '%s'\n", interface->get_mac_address());
 
     return CaseNext;
 }

--- a/TESTS/stress/network-https/main.cpp
+++ b/TESTS/stress/network-https/main.cpp
@@ -27,7 +27,6 @@
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
 
-#include "easy-connect.h"
 #include "tls_socket.h"
 
 using namespace utest::v1;
@@ -176,8 +175,13 @@ void download(size_t size)
 
 static control_t setup_network(const size_t call_count)
 {
-    interface = easy_connect(true);
+    interface = NetworkInterface::get_default_instance();
     TEST_ASSERT_NOT_NULL_MESSAGE(interface, "failed to initialize network");
+
+    nsapi_error_t err = interface->connect();
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    printf("IP address is '%s'\n", interface->get_ip_address());
+    printf("MAC address is '%s'\n", interface->get_mac_address());
 
     return CaseNext;
 }

--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,0 @@
-https://github.com/armmbed/easy-connect/#5b52b5fa56c623d5853c5daf266b34986a0c20cc

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#03196b244ee00fc748cd4dbfa83b26f3fc0f376b
+https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -18,27 +18,21 @@
         "protagonist-file-to-flash": {
             "required": true
         },
-        "network-interface":{
-            "help": "Options are ETHERNET, WIFI_ESP8266, WIFI_ODIN, WIFI_RTW, WIFI_WIZFI310, WIFI_ISM43362",
-            "value": "ETHERNET"
+        "default-wifi-ssid": {
+          "value": "\"\""
         },
-        "wifi-ssid": {
-            "help": "WiFi SSID",
-            "value": "\"SSID\""
+        "default-wifi-password": {
+          "value": "\"\""
         },
-        "wifi-password": {
-            "help": "WiFi Password",
-            "value": "\"Password\""
+        "default-wifi-security": {
+          "value": "\"WPA2\""
         }
     },
     "target_overrides": {
         "*": {
-            "target.features_add": ["COMMON_PAL", "NANOSTACK"],
+            "target.features_add": ["STORAGE"],
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,
-            "storage-selector.storage": "HEAP",
-            "storage-selector.filesystem": "LITTLE",
-            "storage-selector.mount-point": "\"bd\"",
             "app.estimated-application-size": "0x60000",
             "app.protagonist-download": "\"alice.h\"",
             "app.protagonist-file": "\"alice.h\"",
@@ -46,10 +40,15 @@
             "app.protagonist-file-to-flash": "\"alice.h\""
         },
         "DISCO_L475VG_IOT01A": {
-            "app.network-interface": "WIFI_ISM43362"
+            "target.components_add": ["SPIF"]
         },
         "K64F": {
-            "storage-selector.storage": "SD_CARD"
+            "target.network-default-interface-type": "ETHERNET",
+            "target.components_add": ["SD"]
+        },
+        "K66F": {
+            "target.network-default-interface-type": "ETHERNET",
+            "target.components_add": ["SD"]
         },
         "NRF52_DK": {
             "target.extra_labels_remove": [
@@ -59,12 +58,10 @@
             "target.extra_labels_add": [
                 "SOFTDEVICE_NONE"
             ],
-            "app.network-interface": "WIFI_ESP8266",
             "app.estimated-application-size": "0x50000"
         },
         "NRF52840_DK": {
-            "storage-selector.storage": "SPI_FLASH",
-            "app.network-interface": "WIFI_ESP8266",
+            "target.components_add": ["SPIF"],
             "app.estimated-application-size": "0x90000"
         },
         "RZ_A1H": {
@@ -72,11 +69,12 @@
                 "MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES",
                 "MBEDTLS_TEST_NULL_ENTROPY"
             ],
-            "storage-selector.storage": "SD_CARD"
+            "target.components_add": ["SD"]
         },
         "UBLOX_EVK_ODIN_W2": {
-            "target.device_has_remove": ["EMAC"],
-            "storage-selector.storage": "SD_CARD"
+            "target.components_add": ["SD"],
+            "target.network-default-interface-type": "WIFI",
+            "target.device_has_remove": ["EMAC"]
         }
     }
 }

--- a/source/mbed_stress_test_file.cpp
+++ b/source/mbed_stress_test_file.cpp
@@ -16,14 +16,19 @@
 
 #include "mbed.h"
 
-#include "storage-selector/storage-selector.h"
 #include "unity/unity.h"
 
-static FileSystem* fs = filesystem_selector();
+static FileSystem* fs = FileSystem::get_default_instance();
+
+#if COMPONENT_SPIF || COMPONENT_DATAFLASH
+#define MOUNT_POINT "flash"
+#elif COMPONENT_SD
+#define MOUNT_POINT "sd"
+#endif
 
 void mbed_stress_test_format_file(void)
 {
-    BlockDevice* bd = storage_selector();
+    BlockDevice* bd = BlockDevice::get_default_instance();
 
     int result = fs->reformat(bd);
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, result, "could not format block device");
@@ -32,7 +37,7 @@ void mbed_stress_test_format_file(void)
 void mbed_stress_test_write_file(const char* file, size_t offset, const unsigned char* data, size_t data_length, size_t block_size)
 {
     char filename[255] = { 0 };
-    snprintf(filename, 255, "/" MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT "/%s", file);
+    snprintf(filename, 255, "/" MOUNT_POINT "/%s", file);
 
     FILE* output = fopen(filename, "w+");
     TEST_ASSERT_NOT_NULL_MESSAGE(output, "could not open file");
@@ -64,7 +69,7 @@ void mbed_stress_test_write_file(const char* file, size_t offset, const unsigned
 void mbed_stress_test_compare_file(const char* file, size_t offset, const unsigned char* data, size_t data_length, size_t block_size)
 {
     char filename[255] = { 0 };
-    snprintf(filename, 255, "/" MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT "/%s", file);
+    snprintf(filename, 255, "/" MOUNT_POINT "/%s", file);
 
     FILE* output = fopen(filename, "r");
     TEST_ASSERT_NOT_NULL_MESSAGE(output, "could not open file");
@@ -102,7 +107,7 @@ void mbed_stress_test_compare_file(const char* file, size_t offset, const unsign
 size_t mbed_stress_test_read_file(const char* file, size_t offset, unsigned char* buffer, size_t buffer_length)
 {
     char filename[255] = { 0 };
-    snprintf(filename, 255, "/" MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT "/%s", file);
+    snprintf(filename, 255, "/" MOUNT_POINT "/%s", file);
 
     FILE* output = fopen(filename, "r");
     TEST_ASSERT_NOT_NULL_MESSAGE(output, "could not open file");

--- a/storage-selector.lib
+++ b/storage-selector.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/storage-selector/#26411b4ddb735324ffa63ffe6fed92de1fdacd73


### PR DESCRIPTION
Storage and network selection have changed significantly and
current Mbed OS version doesn't include all the previously
supported wifi drivers.

Supported wifi shield:

 * ESP8266